### PR TITLE
Update cordova add plugin documentation to point to proper location

### DIFF
--- a/CORDOVA_GUIDE.md
+++ b/CORDOVA_GUIDE.md
@@ -4,7 +4,7 @@
 
 Branch is available through [Cordova](http://plugins.cordova.io/#/package/io.branchmetrics.branchreferral), to install it simply execute the following line in terminal, while in your project directory:
 
-    cordova plugin add io.branchmetrics.branchreferral
+    cordova plugin add https://github.com/BranchMetrics/Web-SDK.git
 
 ### Register you app
 


### PR DESCRIPTION
I believe the cordova_guide was instructing developers to install the older plugin, as opposed to the new one based on the Web-SDK.