### PR TITLE
Added 'campaign' to properties in resources.link.

### DIFF
--- a/src/1_resources.js
+++ b/src/1_resources.js
@@ -288,6 +288,7 @@ resources.link = {
 		"data": validator(false, validationTypes.str),
 		"tags": validator(false, validationTypes.arr),
 		"feature": validator(false, validationTypes.str),
+		"campaign": validator(false, validationTypes.str),
 		"channel": validator(false, validationTypes.str),
 		"stage": validator(false, validationTypes.str),
 		"type": validator(false, validationTypes.num),


### PR DESCRIPTION
When calling link() and sendSMS(), the 'campaign' parameter is not being sent to the server, as it's not included in the whitelisted parameters in resources.js. This PR fixes that problem.