### PR TITLE
Fix typo on branch.track example in docs

### DIFF
--- a/WEB_GUIDE.md
+++ b/WEB_GUIDE.md
@@ -259,7 +259,7 @@ The `metadata` parameter is a formatted JSON object that can contain any data an
 
 ##### Usage
 ```js
-branch.event(
+branch.track(
     event,
     metadata,
     callback (err)


### PR DESCRIPTION
`branch.event()` doesn't seem to exist.